### PR TITLE
minor fix replacing drop method with __exit__

### DIFF
--- a/docs/key_value.html
+++ b/docs/key_value.html
@@ -45,7 +45,7 @@ def open(name: str) -&gt; Store:
     access to the specified store.
 
     A `spin_sdk.wit.types.Err(spin_sdk.wit.imports.key_value.ErrorStoreTableFull)` will be raised if too many stores have been opened simultaneously.
-    Closing one or more previously opened stores might address this using the `drop` method.
+    Closing one or more previously opened stores might address this using the `__exit__` method.
     
     A `spin_sdk.wit.types.Err(spin_sdk.wit.imports.key_value.ErrorOther(str))` will be raised if some implementation specific error has occured (e.g I/O)
     &#34;&#34;&#34;
@@ -60,7 +60,7 @@ def open_default() -&gt; Store:
     default store.
 
     A `spin_sdk.wit.types.Err(spin_sdk.wit.imports.key_value.ErrorStoreTableFull)` will be raised if too many stores have been opened simultaneously.
-    Closing one or more previously opened stores might address this using the `drop` method.
+    Closing one or more previously opened stores might address this using the `__exit__` method.
 
     A `spin_sdk.wit.types.Err(spin_sdk.wit.imports.key_value.ErrorOther(str))` will be raised if some implementation specific error has occured (e.g I/O)
     &#34;&#34;&#34;
@@ -87,7 +87,7 @@ supplied with the application.</p>
 <p>A <code><a title="spin_sdk.wit.types.Err" href="wit/types.html#spin_sdk.wit.types.Err">Err</a>(<a title="spin_sdk.wit.imports.key_value.ErrorAccessDenied" href="wit/imports/key_value.html#spin_sdk.wit.imports.key_value.ErrorAccessDenied">ErrorAccessDenied</a>)</code> will be raised if the requesting component does not have
 access to the specified store.</p>
 <p>A <code><a title="spin_sdk.wit.types.Err" href="wit/types.html#spin_sdk.wit.types.Err">Err</a>(<a title="spin_sdk.wit.imports.key_value.ErrorStoreTableFull" href="wit/imports/key_value.html#spin_sdk.wit.imports.key_value.ErrorStoreTableFull">ErrorStoreTableFull</a>)</code> will be raised if too many stores have been opened simultaneously.
-Closing one or more previously opened stores might address this using the <code>drop</code> method.</p>
+Closing one or more previously opened stores might address this using the <code>__exit__</code> method.</p>
 <p>A <code><a title="spin_sdk.wit.types.Err" href="wit/types.html#spin_sdk.wit.types.Err">Err</a>(<a title="spin_sdk.wit.imports.key_value.ErrorOther" href="wit/imports/key_value.html#spin_sdk.wit.imports.key_value.ErrorOther">ErrorOther</a>(str))</code> will be raised if some implementation specific error has occured (e.g I/O)</p></div>
 <details class="source">
 <summary>
@@ -107,7 +107,7 @@ Closing one or more previously opened stores might address this using the <code>
     access to the specified store.
 
     A `spin_sdk.wit.types.Err(spin_sdk.wit.imports.key_value.ErrorStoreTableFull)` will be raised if too many stores have been opened simultaneously.
-    Closing one or more previously opened stores might address this using the `drop` method.
+    Closing one or more previously opened stores might address this using the `__exit__` method.
     
     A `spin_sdk.wit.types.Err(spin_sdk.wit.imports.key_value.ErrorOther(str))` will be raised if some implementation specific error has occured (e.g I/O)
     &#34;&#34;&#34;
@@ -123,7 +123,7 @@ Closing one or more previously opened stores might address this using the <code>
 will be raised if the requesting component does not have access to the
 default store.</p>
 <p>A <code><a title="spin_sdk.wit.types.Err" href="wit/types.html#spin_sdk.wit.types.Err">Err</a>(<a title="spin_sdk.wit.imports.key_value.ErrorStoreTableFull" href="wit/imports/key_value.html#spin_sdk.wit.imports.key_value.ErrorStoreTableFull">ErrorStoreTableFull</a>)</code> will be raised if too many stores have been opened simultaneously.
-Closing one or more previously opened stores might address this using the <code>drop</code> method.</p>
+Closing one or more previously opened stores might address this using the <code>__exit__</code> method.</p>
 <p>A <code><a title="spin_sdk.wit.types.Err" href="wit/types.html#spin_sdk.wit.types.Err">Err</a>(<a title="spin_sdk.wit.imports.key_value.ErrorOther" href="wit/imports/key_value.html#spin_sdk.wit.imports.key_value.ErrorOther">ErrorOther</a>(str))</code> will be raised if some implementation specific error has occured (e.g I/O)</p></div>
 <details class="source">
 <summary>
@@ -138,7 +138,7 @@ Closing one or more previously opened stores might address this using the <code>
     default store.
 
     A `spin_sdk.wit.types.Err(spin_sdk.wit.imports.key_value.ErrorStoreTableFull)` will be raised if too many stores have been opened simultaneously.
-    Closing one or more previously opened stores might address this using the `drop` method.
+    Closing one or more previously opened stores might address this using the `__exit__` method.
 
     A `spin_sdk.wit.types.Err(spin_sdk.wit.imports.key_value.ErrorOther(str))` will be raised if some implementation specific error has occured (e.g I/O)
     &#34;&#34;&#34;

--- a/docs/redis.html
+++ b/docs/redis.html
@@ -39,7 +39,7 @@ def open(connection_string: str) -&gt; Connection:
 
     A `spin_sdk.wit.types.Err(spin_sdk.wit.imports.redis.ErrorInvalidAddress)` will be raised if the connection string is invalid.
 
-    A `spin_sdk.wit.types.Err(spin_sdk.wit.imports.redis.ErrorTooManyConnection)` will be raised if there are too many open connections. Closing one or more previously opened connection using the `drop` method might help.
+    A `spin_sdk.wit.types.Err(spin_sdk.wit.imports.redis.ErrorTooManyConnection)` will be raised if there are too many open connections. Closing one or more previously opened connection using the `__exit__` method might help.
     
     A `spin_sdk.wit.types.Err(spin_sdk.wit.imports.redis.ErrorOther(str))` when some other error occurs.
     &#34;&#34;&#34;
@@ -60,7 +60,7 @@ def open(connection_string: str) -&gt; Connection:
 <div class="desc"><p>Open a connection with a Redis database.</p>
 <p>The connection_string is the Redis URL to connect to.</p>
 <p>A <code><a title="spin_sdk.wit.types.Err" href="wit/types.html#spin_sdk.wit.types.Err">Err</a>(<a title="spin_sdk.wit.imports.redis.ErrorInvalidAddress" href="wit/imports/redis.html#spin_sdk.wit.imports.redis.ErrorInvalidAddress">ErrorInvalidAddress</a>)</code> will be raised if the connection string is invalid.</p>
-<p>A <code><a title="spin_sdk.wit.types.Err" href="wit/types.html#spin_sdk.wit.types.Err">Err</a>(spin_sdk.wit.imports.redis.ErrorTooManyConnection)</code> will be raised if there are too many open connections. Closing one or more previously opened connection using the <code>drop</code> method might help.</p>
+<p>A <code><a title="spin_sdk.wit.types.Err" href="wit/types.html#spin_sdk.wit.types.Err">Err</a>(spin_sdk.wit.imports.redis.ErrorTooManyConnection)</code> will be raised if there are too many open connections. Closing one or more previously opened connection using the <code>__exit__</code> method might help.</p>
 <p>A <code><a title="spin_sdk.wit.types.Err" href="wit/types.html#spin_sdk.wit.types.Err">Err</a>(<a title="spin_sdk.wit.imports.redis.ErrorOther" href="wit/imports/redis.html#spin_sdk.wit.imports.redis.ErrorOther">ErrorOther</a>(str))</code> when some other error occurs.</p></div>
 <details class="source">
 <summary>
@@ -74,7 +74,7 @@ def open(connection_string: str) -&gt; Connection:
 
     A `spin_sdk.wit.types.Err(spin_sdk.wit.imports.redis.ErrorInvalidAddress)` will be raised if the connection string is invalid.
 
-    A `spin_sdk.wit.types.Err(spin_sdk.wit.imports.redis.ErrorTooManyConnection)` will be raised if there are too many open connections. Closing one or more previously opened connection using the `drop` method might help.
+    A `spin_sdk.wit.types.Err(spin_sdk.wit.imports.redis.ErrorTooManyConnection)` will be raised if there are too many open connections. Closing one or more previously opened connection using the `__exit__` method might help.
     
     A `spin_sdk.wit.types.Err(spin_sdk.wit.imports.redis.ErrorOther(str))` when some other error occurs.
     &#34;&#34;&#34;

--- a/src/spin_sdk/key_value.py
+++ b/src/spin_sdk/key_value.py
@@ -16,7 +16,7 @@ def open(name: str) -> Store:
     access to the specified store.
 
     A `spin_sdk.wit.types.Err(spin_sdk.wit.imports.key_value.ErrorStoreTableFull)` will be raised if too many stores have been opened simultaneously.
-    Closing one or more previously opened stores might address this using the `drop` method.
+    Closing one or more previously opened stores might address this using the `__exit__` method.
     
     A `spin_sdk.wit.types.Err(spin_sdk.wit.imports.key_value.ErrorOther(str))` will be raised if some implementation specific error has occured (e.g I/O)
     """
@@ -31,7 +31,7 @@ def open_default() -> Store:
     default store.
 
     A `spin_sdk.wit.types.Err(spin_sdk.wit.imports.key_value.ErrorStoreTableFull)` will be raised if too many stores have been opened simultaneously.
-    Closing one or more previously opened stores might address this using the `drop` method.
+    Closing one or more previously opened stores might address this using the `__exit__` method.
 
     A `spin_sdk.wit.types.Err(spin_sdk.wit.imports.key_value.ErrorOther(str))` will be raised if some implementation specific error has occured (e.g I/O)
     """

--- a/src/spin_sdk/redis.py
+++ b/src/spin_sdk/redis.py
@@ -10,7 +10,7 @@ def open(connection_string: str) -> Connection:
 
     A `spin_sdk.wit.types.Err(spin_sdk.wit.imports.redis.ErrorInvalidAddress)` will be raised if the connection string is invalid.
 
-    A `spin_sdk.wit.types.Err(spin_sdk.wit.imports.redis.ErrorTooManyConnection)` will be raised if there are too many open connections. Closing one or more previously opened connection using the `drop` method might help.
+    A `spin_sdk.wit.types.Err(spin_sdk.wit.imports.redis.ErrorTooManyConnection)` will be raised if there are too many open connections. Closing one or more previously opened connection using the `__exit__` method might help.
     
     A `spin_sdk.wit.types.Err(spin_sdk.wit.imports.redis.ErrorOther(str))` when some other error occurs.
     """


### PR DESCRIPTION
replaces mentions of `drop` with `__exit__` as we no longer generate `drop`